### PR TITLE
feat: examples for Node.js runtime APIs

### DIFF
--- a/examples/runtime-apis/nodejs/.gitignore
+++ b/examples/runtime-apis/nodejs/.gitignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/.edge

--- a/examples/runtime-apis/nodejs/async-hooks/main.js
+++ b/examples/runtime-apis/nodejs/async-hooks/main.js
@@ -1,0 +1,43 @@
+/**
+ * An Example of using the Node.js Async Hooks API in an Azion Edge Function.
+ * Support:
+ * - Fully supported
+ * @module runtime-apis/nodejs/async-hooks/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const requestId = new AsyncLocalStorage();
+
+function logAsyncContext(state) {
+  console.log(`${requestId.getStore()} - ${state}`);
+}
+
+function doSomething() {
+  logAsyncContext("log from sync function");
+  setTimeout(() => doSomethingElse(), 100);
+}
+
+function doSomethingElse() {
+  logAsyncContext("log from setTimeout callback");
+}
+
+/**
+ * Example of using the Node.js Async Hooks API
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+async function main(event) {
+  const id = event.request.headers.get("X-Request-Id") ?? "unknown";
+
+  return requestId.run(id, () => {
+    doSomething();
+    logAsyncContext("log from another sync function");
+    return new Response("ok");
+  });
+}
+
+export default main;

--- a/examples/runtime-apis/nodejs/async-hooks/main.js
+++ b/examples/runtime-apis/nodejs/async-hooks/main.js
@@ -1,7 +1,7 @@
 /**
  * An Example of using the Node.js Async Hooks API in an Azion Edge Function.
  * Support:
- * - Fully supported
+ * - Partial support
  * @module runtime-apis/nodejs/async-hooks/main
  * @example
  * // Execute with Azion Bundler:

--- a/examples/runtime-apis/nodejs/buffer/main.js
+++ b/examples/runtime-apis/nodejs/buffer/main.js
@@ -1,0 +1,34 @@
+/**
+ * An example of using the Node.js Buffer API in a Azion Edge Function.
+ * Support:
+ * - Fully supported
+ * @module runtime-apis/nodejs/buffer/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import { Buffer } from "node:buffer";
+
+/**
+ * Example of using the Node.js Buffer API
+ * Writes `string` to `buf` at `offset` according to the character encoding in`encoding`. The `length` parameter is the number of bytes to write. If `buf` did
+ * not contain enough space to fit the entire string, only part of `string` will be
+ * written. However, partially encoded characters will not be written.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  const helloBuffer = Buffer.from("Hello Edge!", "utf8");
+  console.log(helloBuffer.toString("hex"));
+  // 48656c6c6f204564676521
+  console.log(helloBuffer.toString("base64"));
+  // SGVsbG8gRWRnZSE=
+
+  helloBuffer.write("World", 6, 5, "utf8");
+  console.log(helloBuffer.toString());
+  // Hello World!
+  return new Response(helloBuffer.toString(), { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/buffer/main.js
+++ b/examples/runtime-apis/nodejs/buffer/main.js
@@ -1,7 +1,7 @@
 /**
  * An example of using the Node.js Buffer API in a Azion Edge Function.
  * Support:
- * - Fully supported
+ * - Partial support
  * @module runtime-apis/nodejs/buffer/main
  * @example
  * // Execute with Azion Bundler:

--- a/examples/runtime-apis/nodejs/crypto/main.js
+++ b/examples/runtime-apis/nodejs/crypto/main.js
@@ -1,0 +1,34 @@
+/**
+ * An example of using the Node.js Crypto API in a Azion Edge Function.
+ * Support:
+ * - Extended by library `crypto-browserify`
+ * - Implemented aditional methods:
+ *  - randomUUID (named exported only)
+ * @module runtime-apis/nodejs/crypto/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import { createHmac, randomUUID } from "node:crypto";
+
+/**
+ * Example of using the Node.js Crypto API
+ * @param {*} event
+ * @returns
+ */
+const main = async (event) => {
+  const hmac = createHmac("sha256", "a secret");
+  hmac.update("Azion Edge Functions");
+  const hmacResult = hmac.digest("hex");
+  console.log(hmacResult);
+  // 5f2f3c2b9
+
+  const uuid = randomUUID();
+  console.log(uuid);
+  // 1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4c1e
+
+  return new Response(uuid, { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/events/main.js
+++ b/examples/runtime-apis/nodejs/events/main.js
@@ -1,0 +1,29 @@
+/**
+ * An example of using the Node.js `events` module in Azion Edge Functions.
+ * Support:
+ * - Fully supported
+ * - Extended by library `events`
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import { EventEmitter } from "node:events";
+
+/**
+ * Emit an event and listen to it.
+ * @param {*} event
+ * @returns {Response} Response
+ */
+const main = async (event) => {
+  const emitter = new EventEmitter();
+
+  emitter.on("hello-event", (...args) => {
+    console.log("an event occurred!", ...args);
+  });
+
+  emitter.emit("hello-event", 1, 2, 3);
+  return new Response("Event emitted", { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/events/main.js
+++ b/examples/runtime-apis/nodejs/events/main.js
@@ -1,7 +1,7 @@
 /**
  * An example of using the Node.js `events` module in Azion Edge Functions.
  * Support:
- * - Fully supported
+ * - Partial support
  * - Extended by library `events`
  * @example
  * // Execute with Azion Bundler:

--- a/examples/runtime-apis/nodejs/fs/azion.config.cjs
+++ b/examples/runtime-apis/nodejs/fs/azion.config.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  build: {
+    preset: {
+      name: "javascript",
+    },
+    memoryFS: {
+      injectionDirs: ["files/"],
+      removePathPrefix: "files/",
+    },
+  },
+  rules: {
+    request: [
+      {
+        name: "Execute Edge Function",
+        match: "^\\/",
+        behavior: {
+          runFunction: {
+            path: ".edge/worker.js",
+          },
+        },
+      },
+    ],
+  },
+};

--- a/examples/runtime-apis/nodejs/fs/files/hello.txt
+++ b/examples/runtime-apis/nodejs/fs/files/hello.txt
@@ -1,0 +1,1 @@
+Hello FS!

--- a/examples/runtime-apis/nodejs/fs/main.js
+++ b/examples/runtime-apis/nodejs/fs/main.js
@@ -1,0 +1,34 @@
+/**
+ * An example of using the Node.js fs module in Azion's runtime.
+ * Support:
+ * - Partially supported (Custom implementation)
+ * @module runtime-apis/nodejs/fs/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import fs from "node:fs";
+
+const main = async (event) => {
+  // (Sync) in memory file system on bundle
+  // to use sync (read) methods, you need config build.memoryFS (see in azion.config.cjs)
+  const dataReadSync = fs.readFileSync("./hello.txt");
+  console.log("Read File Sync", dataReadSync.toString());
+
+  fs.writeFile("./hello1.txt", "Hello, Azion!", (err) => {
+    if (err) {
+      console.error(err);
+    }
+  });
+
+  // (Async) in Azion's file system
+  const data = await fs.promises.readFile("./hello.txt");
+  console.log("Read File", data.toString());
+
+  await fs.promises.writeFile("./hello2.txt", "Hello, Azion!");
+
+  return new Response("Done!", { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/http/main.js
+++ b/examples/runtime-apis/nodejs/http/main.js
@@ -1,0 +1,49 @@
+/**
+ * An Example of using the Node.js HTTP API in a Azion Edge Function.
+ * Support:
+ * - Extended by library `stream-http`
+ * @module runtime-apis/nodejs/http/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import http from "node:http";
+
+/**
+ * An example of using the Node.js HTTP API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  // this is a workaround to make the http module work in the browser
+  const protocol = event.request.headers.get("x-forwarded-proto") || "http";
+  globalThis.location = {
+    protocol,
+  };
+  return new Promise((resolve, reject) => {
+    http
+      .request("https://jsonplaceholder.typicode.com/todos/1", (res) => {
+        console.log("Got response: " + res.statusCode);
+        let data = "";
+
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+
+        res.on("end", () => {
+          console.log("No more data in response.");
+          console.log("BODY: " + data);
+          resolve(new Response(JSON.stringify(data)));
+        });
+
+        res.on("error", (err) => {
+          console.error(err);
+          reject(new Response("Error occurred"));
+        });
+      })
+      .end();
+  });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/module/main.js
+++ b/examples/runtime-apis/nodejs/module/main.js
@@ -1,0 +1,27 @@
+/**
+ * An Example of using the Node.js Module API in a Azion Edge Function.
+ * Support:
+ * - Partially supported
+ * @module runtime-apis/nodejs/module/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import module from "node:module";
+
+/**
+ * An example of using the Node.js Module API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  return new Promise((resolve, reject) => {
+    module.builtinModules.forEach((moduleName) => {
+      console.log(moduleName);
+    });
+    resolve(new Response("Done"));
+  });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/os/main.js
+++ b/examples/runtime-apis/nodejs/os/main.js
@@ -1,0 +1,26 @@
+/**
+ * An Example of using the Node.js OS API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `os-browserify`)
+ * @module runtime-apis/nodejs/os/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import os from "node:os";
+
+/**
+ * An example of using the Node.js OS API in a Azion Edge Function.
+ * @param {*} event
+ * @returns Promise<Response>
+ */
+const main = async (event) => {
+  return new Promise((resolve, reject) => {
+    const platform = os.platform();
+    console.log("Platform", platform);
+    resolve(new Response(`platform: ${platform}`));
+  });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/path/main.js
+++ b/examples/runtime-apis/nodejs/path/main.js
@@ -1,0 +1,24 @@
+/**
+ * An Example of using the Node.js Path API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `path-browserify`)
+ * @module runtime-apis/nodejs/path/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import path from "node:path";
+
+/**
+ * An example of using the Node.js Path API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  const pathName = path.join("/", "images", "image.jpg");
+  console.log("Path", pathName);
+  return new Response(`Path: ${pathName}`);
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/process/main.js
+++ b/examples/runtime-apis/nodejs/process/main.js
@@ -1,0 +1,29 @@
+/**
+ * An example of using the Node.js Process API in a Azion Edge Function.
+ * Support:
+ *  - Extended by library `process`
+ *    Portions of this file Copyright Roman Shtylman, licensed under the MIT license.
+ * @module runtime-apis/nodejs/process/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import { env, nextTick } from "node:process";
+
+/**
+ * Example of using the process api
+ * @param {*} event
+ */
+const main = async (event) => {
+  console.log(process.env.NODE_ENV);
+
+  nextTick(() => {
+    console.log("Hello, Next Tick!");
+    // Hello, Next Tick!
+  });
+
+  return new Response(`NODE_ENV: ${process.env.NODE_ENV}`, { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/stream/main.js
+++ b/examples/runtime-apis/nodejs/stream/main.js
@@ -1,0 +1,50 @@
+/**
+ * An Example of using Node.js Stream API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `stream-browserify`)
+ * @module runtime-apis/nodejs/stream/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import stream from "node:stream";
+
+/**
+ * An example of using the Node.js Stream API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  return new Promise((resolve, reject) => {
+    const chunks = ["chunk1", "chunk2", "chunk3", "chunk4", "chunk5"];
+
+    const nextChunk = () => {
+      const chunk = chunks.shift();
+      if (chunk) {
+        console.log("Chunk", chunk);
+        nextChunk();
+      }
+    };
+
+    const readable = new stream.Readable({
+      encoding: "utf8",
+      read() {
+        nextChunk();
+      },
+    });
+
+    const writable = new stream.Writable({
+      write(chunk, encoding, callback) {
+        console.log("Chunk", chunk.toString());
+        callback();
+      },
+    });
+
+    readable.pipe(writable);
+
+    resolve(new Response("Done"));
+  });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/string-decoder/main.js
+++ b/examples/runtime-apis/nodejs/string-decoder/main.js
@@ -1,0 +1,28 @@
+/**
+ * An Example of using Node.js StringDecoder API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `string_decoder`)
+ * @module runtime-apis/nodejs/string-decoder/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import string_decoder from "node:string_decoder";
+
+/**
+ * An example of using the Node.js StringDecoder API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  const decoder = new string_decoder.StringDecoder("utf8");
+  const buffer = Buffer.from([0xc2, 0xa2]);
+  const decoded = decoder.write(buffer);
+  console.log(decoded);
+  // ¢
+
+  return new Response(decoded, { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/timers/main.js
+++ b/examples/runtime-apis/nodejs/timers/main.js
@@ -1,0 +1,25 @@
+/**
+ * An Example of using Node.js Timers API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `timers-browserify`)
+ * @module runtime-apis/nodejs/timers/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ *
+ */
+import timers from "node:timers";
+
+/**
+ * An example of using the Node.js Timers API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  console.log("Hello, world!");
+  console.log("Waiting for 5 seconds...");
+  await new Promise((resolve) => timers.setTimeout(resolve, 2000));
+  return new Response("Done!", { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/url/main.js
+++ b/examples/runtime-apis/nodejs/url/main.js
@@ -1,0 +1,42 @@
+/**
+ * An Example of using Node.js URL API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `url`)
+ * @module runtime-apis/nodejs/url/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import url from "node:url";
+
+/**
+ * An example of using the Node.js URL API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  /**
+   * URL globalThis object
+   * https://developer.mozilla.org/en-US/docs/Web/API/URL
+   * if use URL in the browser, don't need to import
+   */
+  const newUrl = new URL("https://example.com/some/path?format=json&page=1");
+  console.log("newURL", newUrl);
+
+  const urlFormated = url.format({
+    protocol: "https",
+    hostname: "example.com",
+    pathname: "/some/path",
+    query: {
+      page: 1,
+      format: "json",
+    },
+  });
+
+  console.log(url.parse(urlFormated));
+
+  return new Response("Done!", { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/util/main.js
+++ b/examples/runtime-apis/nodejs/util/main.js
@@ -1,0 +1,34 @@
+/**
+ * An Example of using Node.js Util API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `util`)
+ * @module runtime-apis/nodejs/util/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import util from "node:util";
+
+const myTest = (callback) => {
+  try {
+    callback(null, "Success!");
+  } catch (err) {
+    callback(err);
+  }
+};
+
+/**
+ * An example of using the Node.js Util API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  const promisifyTest = util.promisify(myTest);
+  const result = await promisifyTest();
+  console.log(util.inspect(result, { showHidden: false, depth: null }));
+
+  return new Response("Done!", { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/vm/main.js
+++ b/examples/runtime-apis/nodejs/vm/main.js
@@ -1,0 +1,31 @@
+/**
+ * An Example of using Node.js VM API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `vm-browserify`)
+ * @module runtime-apis/nodejs/vm/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ * npx edge-functions dev
+ */
+import vm from "node:vm";
+
+// Set a global variable because bundler esbuild minify the code and rename the variable.
+globalThis.contextVar = "initial value";
+
+/**
+ * An example of using the Node.js VM API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  const vmResult = vm.runInThisContext(
+    'globalThis.contextVar = "change by vm";'
+  );
+  console.log(
+    `vmResult: '${vmResult}', globalThis.contextVar: '${globalThis.contextVar}'`
+  );
+  return new Response("Done!", { status: 200 });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/zlib/main.js
+++ b/examples/runtime-apis/nodejs/zlib/main.js
@@ -1,0 +1,30 @@
+/**
+ * An Example of using Node.js Zlib API in a Azion Edge Function.
+ * Support:
+ * - Partially supported (Extended by library `browserify-zlib`)
+ * @module runtime-apis/nodejs/zlib/main
+ * @example
+ * // Execute with Azion Bundler:
+ * npx edge-functions build
+ *
+ */
+import zlib from "node:zlib";
+
+/**
+ * An example of using the Node.js Zlib API in a Azion Edge Function.
+ * @param {*} event
+ * @returns {Promise<Response>}
+ */
+const main = async (event) => {
+  const body = event.body ?? "Hello, World!";
+  const input = Buffer.from(body, "base64");
+  const output = zlib.gzipSync(input);
+  return new Response(output.toString("base64"), {
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Encoding": "gzip",
+    },
+  });
+};
+
+export default main;

--- a/examples/runtime-apis/nodejs/zlib/main.js
+++ b/examples/runtime-apis/nodejs/zlib/main.js
@@ -17,8 +17,12 @@ import zlib from "node:zlib";
  */
 const main = async (event) => {
   const body = event.body ?? "Hello, World!";
-  const input = Buffer.from(body, "base64");
-  const output = zlib.gzipSync(input);
+  const output = zlib.gzipSync(body);
+
+  // decode
+  const decom = zlib.gunzipSync(Buffer.from(output)).toString();
+  console.log(decom);
+
   return new Response(output.toString("base64"), {
     headers: {
       "Content-Type": "application/octet-stream",


### PR DESCRIPTION
### Examples Node.js Runtime APIs

These examples contain partial support and need to be run with the `Azion Bundler`

Use:

1. Enter the example
2. Execute
   - npx edge-functions build
   - npx edge-functions dev

Node.js APIs: 

- async-hooks
- buffer
- crypto
- events
- fs
- http
- module
- os
- path
- process
- stream
- string-decoder
- timers
- url
- util
- vm
- zlib