### PR TITLE
fix: update environment variable name from EDGE_FUNCTION_NAME to FUNCTION_NAME

### DIFF
--- a/examples/runtime-apis/nodejs/fs/azion.config.cjs
+++ b/examples/runtime-apis/nodejs/fs/azion.config.cjs
@@ -28,7 +28,7 @@ module.exports = {
   },
   functions: [
     {
-      name: "$EDGE_FUNCTION_NAME",
+      name: "$FUNCTION_NAME",
       path: "./functions/index.js",
     },
   ],


### PR DESCRIPTION
This pull request makes a small update to the function configuration in `azion.config.cjs`. The function name variable has been changed to improve clarity and consistency.

* Changed the function name variable from `$EDGE_FUNCTION_NAME` to `$FUNCTION_NAME` in the `functions` array of `azion.config.cjs`.