### PR TITLE
refactor: standardize config naming from edge to generic function/application terms

### DIFF
--- a/examples/javascript/simple-js-network-list-with-firewall/azion.config.cjs
+++ b/examples/javascript/simple-js-network-list-with-firewall/azion.config.cjs
@@ -19,8 +19,8 @@
 
 module.exports = {
   build: {
-    entry: ["main.js"],
     preset: "javascript",
+    entry: ["main.js"],
     polyfills: true,
   },
   networkList: [

--- a/examples/javascript/simple-js-network-list/azion.config.cjs
+++ b/examples/javascript/simple-js-network-list/azion.config.cjs
@@ -19,7 +19,6 @@
 
 module.exports = {
   build: {
-    entry: ["index.js"],
     preset: "javascript",
     polyfills: true,
   },
@@ -30,20 +29,20 @@ module.exports = {
       items: ["127.0.0.0/8", "10.0.0.1"],
     },
   ],
-  edgeFunctions: [
+  functions: [
     {
-      name: "$EDGE_FUNCTION_NAME",
+      name: "$FUNCTION_NAME",
       path: "./functions/index.js",
     },
   ],
-  edgeApplications: [
+  applications: [
     {
-      name: "$EDGE_APPLICATION_NAME",
+      name: "$APPLICATION_NAME",
       rules: {
         request: [
           {
-            name: "Execute Edge Function",
-            description: "Execute edge function for all requests",
+            name: "Execute Function",
+            description: "Execute function for all requests",
             active: true,
             criteria: [
               [
@@ -59,7 +58,7 @@ module.exports = {
               {
                 type: "run_function",
                 attributes: {
-                  value: "$EDGE_FUNCTION_NAME",
+                  value: "$FUNCTION_NAME",
                 },
               },
             ],
@@ -68,11 +67,8 @@ module.exports = {
       },
       functionsInstances: [
         {
-          name: "$EDGE_FUNCTION_INSTANCE_NAME",
-          ref: "$EDGE_FUNCTION_NAME",
-          args: {
-            environment: "production",
-          },
+          name: "$FUNCTION_INSTANCE_NAME",
+          ref: "$FUNCTION_NAME",
         },
       ],
     },
@@ -98,7 +94,7 @@ module.exports = {
           strategy: {
             type: "default",
             attributes: {
-              edgeApplication: "$EDGE_APPLICATION_NAME",
+              application: "$APPLICATION_NAME",
             },
           },
         },


### PR DESCRIPTION
This pull request updates the configuration files for the JavaScript network list examples to standardize naming conventions and improve clarity. The main changes include renaming keys and values from "edge" terminology to more generic "function" and "application" terms, and updating function paths for consistency.

**Standardization and Naming Improvements:**

* Renamed configuration keys and values from `edgeFunctions`, `edgeApplications`, and related variables to `functions`, `applications`, and corresponding variables in `azion.config.cjs` for the simple network list example. This improves clarity and consistency across examples. [[1]](diffhunk://#diff-5ba0f4cffc9028efd64f506002b6145ab8807f59521c6aa791c56aed69ca506dL33-R45) [[2]](diffhunk://#diff-5ba0f4cffc9028efd64f506002b6145ab8807f59521c6aa791c56aed69ca506dL62-R61) [[3]](diffhunk://#diff-5ba0f4cffc9028efd64f506002b6145ab8807f59521c6aa791c56aed69ca506dL71-R71) [[4]](diffhunk://#diff-5ba0f4cffc9028efd64f506002b6145ab8807f59521c6aa791c56aed69ca506dL101-R97)
* Updated function and application rule names and descriptions to use the new terminology, e.g., "Execute Function" instead of "Execute Edge Function".
* Changed the function path in the network list with firewall example from `./functions/main.js` to `./functions/index.js` for consistency with other examples.

**Minor Code Organization:**

* Reordered the `entry` field in the `build` configuration for both examples to maintain a consistent structure. [[1]](diffhunk://#diff-57c6cb32d75b77692760cf489a5a6a412f5c8f964e1fa9246148503675e80629L22-R23) [[2]](diffhunk://#diff-5ba0f4cffc9028efd64f506002b6145ab8807f59521c6aa791c56aed69ca506dL22)

These changes help make the configuration files easier to understand and maintain by using consistent terminology and structure.