### PR TITLE
chore(examples): update dependencies in jekyll and sveltekit examples

### DIFF
--- a/examples/jekyll-static/Gemfile
+++ b/examples/jekyll-static/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.3.3"
+gem "jekyll", "~> 4.4.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and

--- a/examples/sveltekit-boilerplate/package.json
+++ b/examples/sveltekit-boilerplate/package.json
@@ -15,13 +15,13 @@
     "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@aziontech/presets": "latest",
     "@eslint/compat": "^2.0.0",
     "@fontsource/fira-mono": "^5.2.7",
     "@neoconfetti/svelte": "^2.2.2",
     "@playwright/test": "^1.57.0",
     "@sveltejs/kit": "^2.49.3",
     "@sveltejs/vite-plugin-svelte": "^6.2.3",
-    "@aziontech/presets": "latest",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.13.1",
@@ -32,6 +32,7 @@
     "svelte-check": "^4.3.5",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.52.0",
+    "vite": "^8.0.10",
     "vitest": "^4.0.16"
   }
 }


### PR DESCRIPTION
- Upgrade Jekyll from 4.3.3 to 4.4.0
- Add vite as dev dependency to sveltekit-boilerplate
- Alphabetically sort devDependencies in sveltekit-boilerplate